### PR TITLE
Support ghc-9.10

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -32,6 +32,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.10.1
+            compilerKind: ghc
+            compilerVersion: 9.10.1
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.8.2
             compilerKind: ghc
             compilerVersion: 9.8.2

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.ghc.environment.*
 /dist-newstyle
+cabal.project.local

--- a/strict-containers-lens/strict-containers-lens.cabal
+++ b/strict-containers-lens/strict-containers-lens.cabal
@@ -24,6 +24,7 @@ tested-with:
    || ==9.4.8
    || ==9.6.5
    || ==9.8.2
+   || ==9.10.1
 
 library
   default-language: Haskell2010

--- a/strict-containers-serialise/strict-containers-serialise.cabal
+++ b/strict-containers-serialise/strict-containers-serialise.cabal
@@ -23,6 +23,7 @@ tested-with:
    || ==9.4.8
    || ==9.6.5
    || ==9.8.2
+   || ==9.10.1
 
 library
   default-language: Haskell2010

--- a/strict-containers-tests/strict-containers-tests.cabal
+++ b/strict-containers-tests/strict-containers-tests.cabal
@@ -19,6 +19,7 @@ tested-with:
    || ==9.4.8
    || ==9.6.5
    || ==9.8.2
+   || ==9.10.1
 
 test-suite strictness-tests
   default-language: Haskell2010

--- a/strict-containers/patches/Vector.patch
+++ b/strict-containers/patches/Vector.patch
@@ -16,10 +16,10 @@ type ([.. ->] a -> ..), e.g. from Data.Primitive.Array or a GHC primop.
 
 For more discussion see https://github.com/haskell/vector/issues/380
 
-diff --git a/src/Data/Strict/Vector/Autogen.hs b/src/Data/Strict/Vector/Autogen.hs
-index ce0814a..fe20777 100644
---- a/src/Data/Strict/Vector/Autogen.hs
-+++ b/src/Data/Strict/Vector/Autogen.hs
+diff --git b/src/Data/Strict/Vector/Autogen.hs a/src/Data/Strict/Vector/Autogen.hs
+index 0e4fdcb..9f526c5 100644
+--- b/src/Data/Strict/Vector/Autogen.hs
++++ a/src/Data/Strict/Vector/Autogen.hs
 @@ -177,8 +177,8 @@ module Data.Strict.Vector.Autogen (
  
  import Data.Strict.Vector.Autogen.Mutable  ( MVector(..) )
@@ -31,7 +31,16 @@ index ce0814a..fe20777 100644
  
  import Control.DeepSeq ( NFData(rnf)
  #if MIN_VERSION_deepseq(1,4,3)
-@@ -291,6 +289,9 @@ instance G.Vector Vector a where
+@@ -199,7 +199,7 @@ import Data.Function ( fix )
+ 
+ import Prelude
+   ( Eq, Ord, Num, Enum, Monoid, Functor, Monad, Show, Bool, Ordering(..), Int, Maybe, Either
+-  , compare, mempty, mappend, mconcat, return, showsPrec, fmap, otherwise, id, flip, const
++  , compare, mempty, mappend, mconcat, return, showsPrec, fmap, otherwise, id, flip, const, seq
+   , (>>=), (+), (-), (<), (<=), (>), (>=), (==), (/=), (&&), (.), ($) )
+ 
+ import Data.Functor.Classes (Eq1 (..), Ord1 (..), Read1 (..), Show1 (..))
+@@ -285,6 +285,9 @@ instance G.Vector Vector a where
    basicUnsafeCopy (MVector i n dst) (Vector j _ src)
      = copyArray dst i src j n
  
@@ -41,10 +50,10 @@ index ce0814a..fe20777 100644
  -- See http://trac.haskell.org/vector/ticket/12
  instance Eq a => Eq (Vector a) where
    {-# INLINE (==) #-}
-diff --git a/src/Data/Strict/Vector/Autogen/Mutable.hs b/src/Data/Strict/Vector/Autogen/Mutable.hs
-index 5d85f12..83af3c4 100644
---- a/src/Data/Strict/Vector/Autogen/Mutable.hs
-+++ b/src/Data/Strict/Vector/Autogen/Mutable.hs
+diff --git b/src/Data/Strict/Vector/Autogen/Mutable.hs a/src/Data/Strict/Vector/Autogen/Mutable.hs
+index 05d8b03..bc2418b 100644
+--- b/src/Data/Strict/Vector/Autogen/Mutable.hs
++++ a/src/Data/Strict/Vector/Autogen/Mutable.hs
 @@ -71,7 +71,7 @@ module Data.Strict.Vector.Autogen.Mutable (
  ) where
  
@@ -54,7 +63,7 @@ index 5d85f12..83af3c4 100644
  import           Data.Strict.Vector.Autogen.Internal.Check
  import           Data.Primitive.Array
  import           Control.Monad.Primitive
-@@ -133,7 +133,7 @@ instance G.MVector MVector a where
+@@ -135,7 +135,7 @@ instance G.MVector MVector a where
    basicInitialize _ = return ()
  
    {-# INLINE basicUnsafeReplicate #-}
@@ -63,7 +72,7 @@ index 5d85f12..83af3c4 100644
      = do
          arr <- newArray n x
          return (MVector 0 n arr)
-@@ -142,7 +142,7 @@ instance G.MVector MVector a where
+@@ -144,7 +144,7 @@ instance G.MVector MVector a where
    basicUnsafeRead (MVector i _ arr) j = readArray arr (i+j)
  
    {-# INLINE basicUnsafeWrite #-}

--- a/strict-containers/patches/tests.patch
+++ b/strict-containers/patches/tests.patch
@@ -101,15 +101,36 @@
  import qualified Data.Vector.Unboxed as Unboxed
 --- a/tests/Utilities.hs
 +++ b/tests/Utilities.hs
-@@ -5,7 +5,7 @@
- import Test.QuickCheck
+@@ -8,6 +8,7 @@
  
  import Data.Foldable
--import qualified Data.Vector as DV
-+import qualified Data.Strict.Vector as DV
+ import Data.Bifunctor
++import qualified Data.Strict.Vector as DSV
+ import qualified Data.Vector as DV
  import qualified Data.Vector.Generic as DVG
  import qualified Data.Vector.Primitive as DVP
- import qualified Data.Vector.Storable as DVS
+@@ -100,6 +101,11 @@
+   model   = map model    . DVU.toList
+   unmodel = DVU.fromList . map unmodel
+ 
++instance (Eq a, TestData a) => TestData (DSV.Vector a) where
++  type Model (DSV.Vector a) = [Model a]
++  model   = map model    . DSV.toList
++  unmodel = DSV.fromList . map unmodel
++
+ #define id_TestData(ty) \
+ instance TestData ty where { \
+   type Model ty = ty;        \
+@@ -346,3 +352,9 @@
+     | ours >= 0
+     , Just (out, theirs') <- f theirs = Just (out, (theirs', ours - 1))
+     | otherwise                       = Nothing
++
++instance Arbitrary a => Arbitrary (DSV.Vector a) where
++  arbitrary = fmap DSV.fromList arbitrary
++
++instance CoArbitrary a => CoArbitrary (DSV.Vector a) where
++    coarbitrary = coarbitrary . DSV.toList
 --- a/tests/intmap-strictness.hs
 +++ b/tests/intmap-strictness.hs
 @@ -1,4 +1,5 @@
@@ -244,3 +265,14 @@
  
  
  -- DO NOT EDIT above, AUTOGEN tests
+--- a/strict-containers.cabal
++++ b/strict-containers.cabal
+@@ -162,7 +162,7 @@ common containers-deps
+   build-depends:
+       array    >=0.4.0.0
+     , base     >=4.10    && <5
+-    , deepseq  >=1.2     && <1.5
++    , deepseq  >=1.2     && <1.6
+     , template-haskell
+ 
+ common containers-test-deps

--- a/strict-containers/regen.sh
+++ b/strict-containers/regen.sh
@@ -112,7 +112,7 @@ if [ -z "$CLEAN" ]; then
 	VERSIONS_CABAL=versions.cabal.in
 	rm -f $VERSIONS_CABAL
 	ensure_checkout containers v0.6.6
-	ensure_checkout unordered-containers v0.2.19.1
+	ensure_checkout unordered-containers v0.2.20
 	ensure_checkout vector vector-0.13.0.0
 	cat $VERSIONS_CABAL | fixup_cabal versions ""
 	rm -f $VERSIONS_CABAL

--- a/strict-containers/regen.sh
+++ b/strict-containers/regen.sh
@@ -111,7 +111,7 @@ copy_test_and_rename() {
 if [ -z "$CLEAN" ]; then
 	VERSIONS_CABAL=versions.cabal.in
 	rm -f $VERSIONS_CABAL
-	ensure_checkout containers v0.6.6
+	ensure_checkout containers v0.7
 	ensure_checkout unordered-containers v0.2.20
 	ensure_checkout vector vector-0.13.1.0
 	cat $VERSIONS_CABAL | fixup_cabal versions ""

--- a/strict-containers/regen.sh
+++ b/strict-containers/regen.sh
@@ -113,7 +113,7 @@ if [ -z "$CLEAN" ]; then
 	rm -f $VERSIONS_CABAL
 	ensure_checkout containers v0.6.6
 	ensure_checkout unordered-containers v0.2.20
-	ensure_checkout vector vector-0.13.0.0
+	ensure_checkout vector vector-0.13.1.0
 	cat $VERSIONS_CABAL | fixup_cabal versions ""
 	rm -f $VERSIONS_CABAL
 else

--- a/strict-containers/src/Data/Strict/ContainersUtils/Autogen/Prelude.hs
+++ b/strict-containers/src/Data/Strict/ContainersUtils/Autogen/Prelude.hs
@@ -1,0 +1,12 @@
+-- | This hideous module lets us avoid dealing with the fact that
+-- @liftA2@ and @foldl'@ were not previously exported from the standard prelude.
+module Data.Strict.ContainersUtils.Autogen.Prelude
+  ( module Prelude
+  , Applicative (..)
+  , Foldable (..)
+  )
+  where
+
+import Prelude hiding (Applicative(..), Foldable(..))
+import Control.Applicative(Applicative(..))
+import Data.Foldable (Foldable(elem, foldMap, foldr, foldl, foldl', foldr1, foldl1, maximum, minimum, product, sum, null, length))

--- a/strict-containers/src/Data/Strict/ContainersUtils/Autogen/State.hs
+++ b/strict-containers/src/Data/Strict/ContainersUtils/Autogen/State.hs
@@ -6,7 +6,9 @@
 module Data.Strict.ContainersUtils.Autogen.State where
 
 import Control.Monad (ap, liftM2)
-import Control.Applicative (Applicative(..), liftA)
+import Control.Applicative (liftA)
+import Data.Strict.ContainersUtils.Autogen.Prelude
+import Prelude ()
 
 newtype State s a = State {runState :: s -> (s, a)}
 
@@ -26,9 +28,7 @@ instance Applicative (State s) where
     (<*>) = ap
     m *> n = State $ \s -> case runState m s of
       (s', _) -> runState n s'
-#if MIN_VERSION_base(4,10,0)
     liftA2 = liftM2
-#endif
 
 execState :: State s a -> s -> a
 execState m x = snd (runState m x)

--- a/strict-containers/src/Data/Strict/HashMap/Autogen/Internal/Array.hs
+++ b/strict-containers/src/Data/Strict/HashMap/Autogen/Internal/Array.hs
@@ -52,7 +52,6 @@ module Data.Strict.HashMap.Autogen.Internal.Array
     , insertM
     , delete
     , sameArray1
-    , trim
 
     , unsafeFreeze
     , unsafeThaw
@@ -60,6 +59,7 @@ module Data.Strict.HashMap.Autogen.Internal.Array
     , run
     , copy
     , copyM
+    , cloneM
 
       -- * Folds
     , foldl
@@ -94,7 +94,7 @@ import GHC.Exts            (Int (..), SmallArray#, SmallMutableArray#,
                             unsafeFreezeSmallArray#, unsafeThawSmallArray#,
                             writeSmallArray#)
 import GHC.ST              (ST (..))
-import Prelude             hiding (all, filter, foldMap, foldl, foldr, length,
+import Prelude             hiding (Foldable(..), all, filter,
                             map, read, traverse)
 
 import qualified GHC.Exts                   as Exts
@@ -322,11 +322,6 @@ cloneM _mary@(MArray mary#) _off@(I# off#) _len@(I# len#) =
     case cloneSmallMutableArray# mary# off# len# s of
       (# s', mary'# #) -> (# s', MArray mary'# #)
 
--- | Create a new array of the @n@ first elements of @mary@.
-trim :: MArray s a -> Int -> ST s (Array a)
-trim mary n = cloneM mary 0 n >>= unsafeFreeze
-{-# INLINE trim #-}
-
 -- | \(O(n)\) Insert an element at the given position in this array,
 -- increasing its size by one.
 insert :: Array e -> Int -> e -> Array e
@@ -360,7 +355,7 @@ updateM ary idx b =
   where !count = length ary
 {-# INLINE updateM #-}
 
--- | \(O(n)\) Update the element at the given positio in this array, by
+-- | \(O(n)\) Update the element at the given position in this array, by
 -- applying a function to it.  Evaluates the element to WHNF before
 -- inserting it into the array.
 updateWith' :: Array e -> Int -> (e -> e) -> Array e

--- a/strict-containers/src/Data/Strict/HashMap/Autogen/Internal/Debug.hs
+++ b/strict-containers/src/Data/Strict/HashMap/Autogen/Internal/Debug.hs
@@ -1,0 +1,149 @@
+{-# LANGUAGE CPP              #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | = WARNING
+--
+-- This module is considered __internal__.
+--
+-- The Package Versioning Policy __does not apply__.
+--
+-- The contents of this module may change __in any way whatsoever__
+-- and __without any warning__ between minor versions of this package.
+--
+-- Authors importing this module are expected to track development
+-- closely.
+--
+-- = Description
+--
+-- Debugging utilities for 'HashMap's.
+
+module Data.Strict.HashMap.Autogen.Internal.Debug
+    ( valid
+    , Validity(..)
+    , Error(..)
+    , SubHash
+    , SubHashPath
+    ) where
+
+import Data.Bits             (complement, countTrailingZeros, popCount, shiftL,
+                              unsafeShiftL, (.&.), (.|.))
+import Data.Hashable         (Hashable)
+import Data.Strict.HashMap.Autogen.Internal (Bitmap, Hash, HashMap (..), Leaf (..),
+                              bitsPerSubkey, fullBitmap, hash,
+                              isLeafOrCollision, maxChildren, sparseIndex)
+import Data.Semigroup        (Sum (..))
+
+import qualified Data.Strict.HashMap.Autogen.Internal.Array as A
+
+
+#if !MIN_VERSION_base(4,11,0)
+import Data.Semigroup (Semigroup (..))
+#endif
+
+data Validity k = Invalid (Error k) SubHashPath | Valid
+  deriving (Eq, Show)
+
+instance Semigroup (Validity k) where
+  Valid <> y = y
+  x     <> _ = x
+
+instance Monoid (Validity k) where
+  mempty = Valid
+  mappend = (<>)
+
+-- | An error corresponding to a broken invariant.
+--
+-- See 'HashMap' for the documentation of the invariants.
+data Error k
+  = INV1_internal_Empty
+  | INV2_Bitmap_unexpected_1_bits !Bitmap
+  | INV3_bad_BitmapIndexed_size !Int
+  | INV4_bitmap_array_size_mismatch !Bitmap !Int
+  | INV5_BitmapIndexed_invalid_single_subtree
+  | INV6_misplaced_hash !Hash
+  | INV7_key_hash_mismatch k !Hash
+  | INV8_bad_Full_size !Int
+  | INV9_Collision_size !Int
+  | INV10_Collision_duplicate_key k !Hash
+  deriving (Eq, Show)
+
+-- TODO: Name this 'Index'?!
+-- (https://github.com/haskell-unordered-containers/unordered-containers/issues/425)
+-- | A part of a 'Hash' with 'bitsPerSubkey' bits.
+type SubHash = Word
+
+data SubHashPath = SubHashPath
+  { partialHash :: !Word
+    -- ^ The bits we already know, starting from the lower bits.
+    -- The unknown upper bits are @0@.
+  , lengthInBits :: !Int
+    -- ^ The number of bits known.
+  } deriving (Eq, Show)
+
+initialSubHashPath :: SubHashPath
+initialSubHashPath = SubHashPath 0 0
+
+addSubHash :: SubHashPath -> SubHash -> SubHashPath
+addSubHash (SubHashPath ph l) sh =
+  SubHashPath (ph .|. (sh `unsafeShiftL` l)) (l + bitsPerSubkey)
+
+hashMatchesSubHashPath :: SubHashPath -> Hash -> Bool
+hashMatchesSubHashPath (SubHashPath ph l) h = maskToLength h l == ph
+  where
+    -- Note: This needs to use `shiftL` instead of `unsafeShiftL` because
+    -- @l'@ may be greater than 32/64 at the deepest level.
+    maskToLength h' l' = h' .&. complement (complement 0 `shiftL` l')
+
+valid :: Hashable k => HashMap k v -> Validity k
+valid Empty = Valid
+valid t     = validInternal initialSubHashPath t
+  where
+    validInternal p Empty                 = Invalid INV1_internal_Empty p
+    validInternal p (Leaf h l)            = validHash p h <> validLeaf p h l
+    validInternal p (Collision h ary)     = validHash p h <> validCollision p h ary
+    validInternal p (BitmapIndexed b ary) = validBitmapIndexed p b ary
+    validInternal p (Full ary)            = validFull p ary
+
+    validHash p h | hashMatchesSubHashPath p h = Valid
+                  | otherwise                  = Invalid (INV6_misplaced_hash h) p
+
+    validLeaf p h (L k _) | hash k == h = Valid
+                          | otherwise   = Invalid (INV7_key_hash_mismatch k h) p
+
+    validCollision p h ary = validCollisionSize <> A.foldMap (validLeaf p h) ary <> distinctKeys
+      where
+        n = A.length ary
+        validCollisionSize | n < 2     = Invalid (INV9_Collision_size n) p
+                           | otherwise = Valid
+        distinctKeys = A.foldMap (\(L k _) -> appearsOnce k) ary
+        appearsOnce k | A.foldMap (\(L k' _) -> if k' == k then Sum @Int 1 else Sum 0) ary == 1 = Valid
+                      | otherwise = Invalid (INV10_Collision_duplicate_key k h) p
+
+    validBitmapIndexed p b ary = validBitmap <> validArraySize <> validSubTrees p b ary
+      where
+        validBitmap | b .&. complement fullBitmap == 0 = Valid
+                    | otherwise                        = Invalid (INV2_Bitmap_unexpected_1_bits b) p
+        n = A.length ary
+        validArraySize | n < 1 || n >= maxChildren = Invalid (INV3_bad_BitmapIndexed_size n) p
+                       | popCount b == n           = Valid
+                       | otherwise                 = Invalid (INV4_bitmap_array_size_mismatch b n) p
+
+    validSubTrees p b ary
+      | A.length ary == 1
+      , isLeafOrCollision (A.index ary 0)
+      = Invalid INV5_BitmapIndexed_invalid_single_subtree p
+      | otherwise = go b
+      where
+        go 0  = Valid
+        go b' = validInternal (addSubHash p (fromIntegral c)) (A.index ary i) <> go b''
+          where
+            c = countTrailingZeros b'
+            m = 1 `unsafeShiftL` c
+            i = sparseIndex b m
+            b'' = b' .&. complement m
+
+    validFull p ary = validArraySize <> validSubTrees p fullBitmap ary
+      where
+        n = A.length ary
+        validArraySize | n == maxChildren = Valid
+                       | otherwise        = Invalid (INV8_bad_Full_size n) p

--- a/strict-containers/src/Data/Strict/HashMap/Autogen/Internal/List.hs
+++ b/strict-containers/src/Data/Strict/HashMap/Autogen/Internal/List.hs
@@ -32,7 +32,7 @@ import Data.Maybe (fromMaybe)
 import Data.Semigroup ((<>))
 #endif
 
--- Note: previous implemenation isPermutation = null (as // bs)
+-- Note: previous implementation isPermutation = null (as // bs)
 -- was O(n^2) too.
 --
 -- This assumes lists are of equal length
@@ -53,7 +53,7 @@ isPermutationBy f = go
 
 -- The idea:
 --
--- Homogeonous version
+-- Homogenous version
 --
 -- uc :: (a -> a -> Ordering) -> [a] -> [a] -> Ordering
 -- uc c as bs = compare (sortBy c as) (sortBy c bs)

--- a/strict-containers/src/Data/Strict/IntMap/Autogen/Strict.hs
+++ b/strict-containers/src/Data/Strict/IntMap/Autogen/Strict.hs
@@ -217,6 +217,10 @@ module Data.Strict.IntMap.Autogen.Strict (
     , partition
     , partitionWithKey
 
+    , takeWhileAntitone
+    , dropWhileAntitone
+    , spanAntitone
+
     , mapMaybe
     , mapMaybeWithKey
     , mapEither

--- a/strict-containers/src/Data/Strict/IntMap/Autogen/Strict/Internal.hs
+++ b/strict-containers/src/Data/Strict/IntMap/Autogen/Strict/Internal.hs
@@ -217,6 +217,10 @@ module Data.Strict.IntMap.Autogen.Strict.Internal (
     , partition
     , partitionWithKey
 
+    , takeWhileAntitone
+    , dropWhileAntitone
+    , spanAntitone
+
     , mapMaybe
     , mapMaybeWithKey
     , mapEither
@@ -255,7 +259,9 @@ module Data.Strict.IntMap.Autogen.Strict.Internal (
 #endif
     ) where
 
-import Prelude hiding (lookup,map,filter,foldr,foldl,null)
+import Data.Strict.ContainersUtils.Autogen.Prelude hiding
+  (lookup,map,filter,foldr,foldl,foldl',null)
+import Prelude ()
 
 import Data.Bits
 import qualified Data.Strict.IntMap.Autogen.Internal as L
@@ -327,6 +333,9 @@ import Data.Strict.IntMap.Autogen.Internal
   , null
   , partition
   , partitionWithKey
+  , takeWhileAntitone
+  , dropWhileAntitone
+  , spanAntitone
   , restrictKeys
   , size
   , split
@@ -345,7 +354,6 @@ import Data.Strict.IntMap.Autogen.Internal.DeprecatedDebug (showTree, showTreeWi
 import qualified Data.IntSet.Internal as IntSet
 import Data.Strict.ContainersUtils.Autogen.BitUtil
 import Data.Strict.ContainersUtils.Autogen.StrictPair
-import Control.Applicative (Applicative (..), liftA2)
 import qualified Data.Foldable as Foldable
 
 {--------------------------------------------------------------------
@@ -417,6 +425,8 @@ insert !k !x t =
 -- > insertWith (++) 5 "xxx" (fromList [(5,"a"), (3,"b")]) == fromList [(3, "b"), (5, "xxxa")]
 -- > insertWith (++) 7 "xxx" (fromList [(5,"a"), (3,"b")]) == fromList [(3, "b"), (5, "a"), (7, "xxx")]
 -- > insertWith (++) 5 "xxx" empty                         == singleton 5 "xxx"
+--
+-- Also see the performance note on 'fromListWith'.
 
 insertWith :: (a -> a -> a) -> Key -> a -> IntMap a -> IntMap a
 insertWith f k x t
@@ -435,6 +445,8 @@ insertWith f k x t
 --
 -- If the key exists in the map, this function is lazy in @value@ but strict
 -- in the result of @f@.
+--
+-- Also see the performance note on 'fromListWith'.
 
 insertWithKey :: (Key -> a -> a -> a) -> Key -> a -> IntMap a -> IntMap a
 insertWithKey f !k x t =
@@ -462,6 +474,8 @@ insertWithKey f !k x t =
 -- > let insertLookup kx x t = insertLookupWithKey (\_ a _ -> a) kx x t
 -- > insertLookup 5 "x" (fromList [(5,"a"), (3,"b")]) == (Just "a", fromList [(3, "b"), (5, "x")])
 -- > insertLookup 7 "x" (fromList [(5,"a"), (3,"b")]) == (Nothing,  fromList [(3, "b"), (5, "a"), (7, "x")])
+--
+-- Also see the performance note on 'fromListWith'.
 
 insertLookupWithKey :: (Key -> a -> a -> a) -> Key -> a -> IntMap a -> (Maybe a, IntMap a)
 insertLookupWithKey f0 !k0 x0 t0 = toPair $ go f0 k0 x0 t0
@@ -652,6 +666,8 @@ unionsWith f ts
 -- | \(O(n+m)\). The union with a combining function.
 --
 -- > unionWith (++) (fromList [(5, "a"), (3, "b")]) (fromList [(5, "A"), (7, "C")]) == fromList [(3, "b"), (5, "aA"), (7, "C")]
+--
+-- Also see the performance note on 'fromListWith'.
 
 unionWith :: (a -> a -> a) -> IntMap a -> IntMap a -> IntMap a
 unionWith f m1 m2
@@ -661,6 +677,8 @@ unionWith f m1 m2
 --
 -- > let f key left_value right_value = (show key) ++ ":" ++ left_value ++ "|" ++ right_value
 -- > unionWithKey f (fromList [(5, "a"), (3, "b")]) (fromList [(5, "A"), (7, "C")]) == fromList [(3, "b"), (5, "5:a|A"), (7, "C")]
+--
+-- Also see the performance note on 'fromListWith'.
 
 unionWithKey :: (Key -> a -> a -> a) -> IntMap a -> IntMap a -> IntMap a
 unionWithKey f m1 m2
@@ -978,6 +996,8 @@ mapAccumRWithKey f0 a0 t0 = toPair $ go f0 a0 t0
 --
 -- > mapKeysWith (++) (\ _ -> 1) (fromList [(1,"b"), (2,"a"), (3,"d"), (4,"c")]) == singleton 1 "cdab"
 -- > mapKeysWith (++) (\ _ -> 3) (fromList [(1,"b"), (2,"a"), (3,"d"), (4,"c")]) == singleton 3 "cdab"
+--
+-- Also see the performance note on 'fromListWith'.
 
 mapKeysWith :: (a -> a -> a) -> (Key->Key) -> IntMap a -> IntMap a
 mapKeysWith c f = fromListWith c . foldrWithKey (\k x xs -> (f k, x) : xs) []
@@ -1087,10 +1107,41 @@ fromList xs
   where
     ins t (k,x)  = insert k x t
 
--- | \(O(n \min(n,W))\). Create a map from a list of key\/value pairs with a combining function. See also 'fromAscListWith'.
+-- | \(O(n \min(n,W))\). Build a map from a list of key\/value pairs with a combining function. See also 'fromAscListWith'.
 --
--- > fromListWith (++) [(5,"a"), (5,"b"), (3,"b"), (3,"a"), (5,"a")] == fromList [(3, "ab"), (5, "aba")]
+-- > fromListWith (++) [(5,"a"), (5,"b"), (3,"x"), (5,"c")] == fromList [(3, "x"), (5, "cba")]
 -- > fromListWith (++) [] == empty
+--
+-- Note the reverse ordering of @"cba"@ in the example.
+--
+-- The symmetric combining function @f@ is applied in a left-fold over the list, as @f new old@.
+--
+-- === Performance
+--
+-- You should ensure that the given @f@ is fast with this order of arguments.
+--
+-- Symmetric functions may be slow in one order, and fast in another.
+-- For the common case of collecting values of matching keys in a list, as above:
+--
+-- The complexity of @(++) a b@ is \(O(a)\), so it is fast when given a short list as its first argument.
+-- Thus:
+--
+-- > fromListWith       (++)  (replicate 1000000 (3, "x"))   -- O(n),  fast
+-- > fromListWith (flip (++)) (replicate 1000000 (3, "x"))   -- O(n²), extremely slow
+--
+-- because they evaluate as, respectively:
+--
+-- > fromList [(3, "x" ++ ("x" ++ "xxxxx..xxxxx"))]   -- O(n)
+-- > fromList [(3, ("xxxxx..xxxxx" ++ "x") ++ "x")]   -- O(n²)
+--
+-- Thus, to get good performance with an operation like @(++)@ while also preserving
+-- the same order as in the input list, reverse the input:
+--
+-- > fromListWith (++) (reverse [(5,"a"), (5,"b"), (5,"c")]) == fromList [(5, "abc")]
+--
+-- and it is always fast to combine singleton-list values @[v]@ with @fromListWith (++)@, as in:
+--
+-- > fromListWith (++) $ reverse $ map (\(k, v) -> (k, [v])) someListOfTuples
 
 fromListWith :: (a -> a -> a) -> [(Key,a)] -> IntMap a
 fromListWith f xs
@@ -1098,8 +1149,11 @@ fromListWith f xs
 
 -- | \(O(n \min(n,W))\). Build a map from a list of key\/value pairs with a combining function. See also fromAscListWithKey'.
 --
--- > fromListWith (++) [(5,"a"), (5,"b"), (3,"b"), (3,"a"), (5,"a")] == fromList [(3, "ab"), (5, "aba")]
--- > fromListWith (++) [] == empty
+-- > let f key new_value old_value = show key ++ ":" ++ new_value ++ "|" ++ old_value
+-- > fromListWithKey f [(5,"a"), (5,"b"), (3,"b"), (3,"a"), (5,"c")] == fromList [(3, "3:a|b"), (5, "5:c|5:b|a")]
+-- > fromListWithKey f [] == empty
+--
+-- Also see the performance note on 'fromListWith'.
 
 fromListWithKey :: (Key -> a -> a -> a) -> [(Key,a)] -> IntMap a
 fromListWithKey f xs
@@ -1122,6 +1176,8 @@ fromAscList = fromMonoListWithKey Nondistinct (\_ x _ -> x)
 -- /The precondition (input list is ascending) is not checked./
 --
 -- > fromAscListWith (++) [(3,"b"), (5,"a"), (5,"b")] == fromList [(3, "b"), (5, "ba")]
+--
+-- Also see the performance note on 'fromListWith'.
 
 fromAscListWith :: (a -> a -> a) -> [(Key,a)] -> IntMap a
 fromAscListWith f = fromMonoListWithKey Nondistinct (\_ x y -> f x y)
@@ -1132,6 +1188,8 @@ fromAscListWith f = fromMonoListWithKey Nondistinct (\_ x y -> f x y)
 -- /The precondition (input list is ascending) is not checked./
 --
 -- > fromAscListWith (++) [(3,"b"), (5,"a"), (5,"b")] == fromList [(3, "b"), (5, "ba")]
+--
+-- Also see the performance note on 'fromListWith'.
 
 fromAscListWithKey :: (Key -> a -> a -> a) -> [(Key,a)] -> IntMap a
 fromAscListWithKey f = fromMonoListWithKey Nondistinct f
@@ -1153,6 +1211,8 @@ fromDistinctAscList = fromMonoListWithKey Distinct (\_ x _ -> x)
 -- The precise conditions under which this function works are subtle:
 -- For any branch mask, keys with the same prefix w.r.t. the branch
 -- mask must occur consecutively in the list.
+--
+-- Also see the performance note on 'fromListWith'.
 
 fromMonoListWithKey :: Distinct -> (Key -> a -> a -> a) -> [(Key,a)] -> IntMap a
 fromMonoListWithKey distinct f = go

--- a/strict-containers/src/Data/Strict/Map/Autogen/Internal/Debug.hs
+++ b/strict-containers/src/Data/Strict/Map/Autogen/Internal/Debug.hs
@@ -6,7 +6,7 @@ module Data.Strict.Map.Autogen.Internal.Debug where
 import Data.Strict.Map.Autogen.Internal (Map (..), size, delta)
 import Control.Monad (guard)
 
--- | \(O(n)\). Show the tree that implements the map. The tree is shown
+-- | \(O(n \log n)\). Show the tree that implements the map. The tree is shown
 -- in a compressed, hanging format. See 'showTreeWith'.
 showTree :: (Show k,Show a) => Map k a -> String
 showTree m
@@ -15,7 +15,7 @@ showTree m
     showElem k x  = show k ++ ":=" ++ show x
 
 
-{- | \(O(n)\). The expression (@'showTreeWith' showelem hang wide map@) shows
+{- | \(O(n \log n)\). The expression (@'showTreeWith' showelem hang wide map@) shows
  the tree that implements the map. Elements are shown using the @showElem@ function. If @hang@ is
  'True', a /hanging/ tree is shown otherwise a rotated tree is shown. If
  @wide@ is 'True', an extra wide version is shown.
@@ -91,7 +91,7 @@ showsBars :: [String] -> ShowS
 showsBars bars
   = case bars of
       [] -> id
-      _  -> showString (concat (reverse (tail bars))) . showString node
+      _ : tl -> showString (concat (reverse tl)) . showString node
 
 node :: String
 node           = "+--"

--- a/strict-containers/src/Data/Strict/Map/Autogen/Internal/DeprecatedShowTree.hs
+++ b/strict-containers/src/Data/Strict/Map/Autogen/Internal/DeprecatedShowTree.hs
@@ -1,12 +1,4 @@
-{-# LANGUAGE CPP, FlexibleContexts, DataKinds #-}
-#if __GLASGOW_HASKELL__ >= 800
-{-# LANGUAGE MonoLocalBinds #-}
-#endif
-#if __GLASGOW_HASKELL__ < 710
--- Why do we need this? Guess it doesn't matter; this is all
--- going away soon.
-{-# LANGUAGE Trustworthy #-}
-#endif
+{-# LANGUAGE CPP, FlexibleContexts, DataKinds, MonoLocalBinds #-}
 
 #include "containers.h"
 

--- a/strict-containers/src/Data/Strict/Sequence/Autogen.hs
+++ b/strict-containers/src/Data/Strict/Sequence/Autogen.hs
@@ -249,7 +249,6 @@ import Data.Strict.Sequence.Autogen.Internal.Sorting
 import Prelude ()
 #ifdef __HADDOCK_VERSION__
 import Control.Monad (Monad (..))
-import Control.Applicative (Applicative (..))
 import Data.Functor (Functor (..))
 #endif
 

--- a/strict-containers/src/Data/Strict/Vector/Autogen/Internal/Check.hs
+++ b/strict-containers/src/Data/Strict/Vector/Autogen/Internal/Check.hs
@@ -27,7 +27,10 @@ module Data.Strict.Vector.Autogen.Internal.Check (
 ) where
 
 import GHC.Exts (Int(..), Int#)
-import Prelude hiding( error, (&&), (||), not )
+import Prelude
+  ( Eq, Bool(..), Word, String
+  , otherwise, fromIntegral, show, unlines
+  , (-), (<), (<=), (>=), ($), (++) )
 import qualified Prelude as P
 import GHC.Stack (HasCallStack)
 

--- a/strict-containers/src/Data/Strict/Vector/Autogen/Mutable.hs
+++ b/strict-containers/src/Data/Strict/Vector/Autogen/Mutable.hs
@@ -76,8 +76,10 @@ import           Data.Strict.Vector.Autogen.Internal.Check
 import           Data.Primitive.Array
 import           Control.Monad.Primitive
 
-import Prelude hiding ( length, null, replicate, reverse, read,
-                        take, drop, splitAt, init, tail, foldr, foldl, mapM_ )
+import Prelude
+  ( Ord, Monad, Bool, Ordering(..), Int, Maybe
+  , compare, return, otherwise, error
+  , (>>=), (+), (-), (*), (<), (>), (>=), (&&), (||), ($), (>>) )
 
 import Data.Typeable ( Typeable )
 
@@ -742,3 +744,6 @@ fromMutableArray marr =
 toMutableArray :: PrimMonad m => MVector (PrimState m) a -> m (MutableArray (PrimState m) a)
 {-# INLINE toMutableArray #-}
 toMutableArray (MVector offset size marr) = cloneMutableArray marr offset size
+
+-- $setup
+-- >>> import Prelude (Integer)

--- a/strict-containers/strict-containers.cabal
+++ b/strict-containers/strict-containers.cabal
@@ -67,6 +67,7 @@ tested-with:
    || ==9.4.8
    || ==9.6.5
    || ==9.8.2
+   || ==9.10.1
 
 library
   default-language: Haskell2010

--- a/strict-containers/strict-containers.cabal
+++ b/strict-containers/strict-containers.cabal
@@ -39,7 +39,7 @@ Description:
   .
 -- generated list for versions
 -- DO NOT EDIT below, AUTOGEN versions
-  * containers v0.6.6
+  * containers v0.7
   * unordered-containers v0.2.20
   * vector vector-0.13.1.0
 -- DO NOT EDIT above, AUTOGEN versions
@@ -141,6 +141,7 @@ library
     Data.Strict.ContainersUtils.Autogen.StrictMaybe
     Data.Strict.ContainersUtils.Autogen.StrictPair
     Data.Strict.ContainersUtils.Autogen.State
+    Data.Strict.ContainersUtils.Autogen.Prelude
     Data.Strict.ContainersUtils.Autogen.BitUtil
     Data.Strict.ContainersUtils.Autogen.Coercions
     -- DO NOT EDIT above, AUTOGEN ContainersUtils
@@ -160,7 +161,7 @@ library
 common containers-deps
   build-depends:
       array    >=0.4.0.0
-    , base     >=4.9.1   && <5
+    , base     >=4.10    && <5
     , deepseq  >=1.2     && <1.6
     , template-haskell
 
@@ -277,7 +278,7 @@ test-suite vector-tests-O0
   hs-source-dirs: tests
   Build-Depends: base >= 4.5 && < 5, template-haskell, base-orphans >= 0.6, vector, strict-containers,
                  primitive, random,
-                 QuickCheck >= 2.9 && < 2.16, HUnit, tasty,
+                 QuickCheck >= 2.9 && < 2.15, HUnit, tasty,
                  tasty-hunit, tasty-quickcheck,
                  transformers >= 0.2.0.0
 

--- a/strict-containers/strict-containers.cabal
+++ b/strict-containers/strict-containers.cabal
@@ -40,7 +40,7 @@ Description:
 -- generated list for versions
 -- DO NOT EDIT below, AUTOGEN versions
   * containers v0.6.6
-  * unordered-containers v0.2.19.1
+  * unordered-containers v0.2.20
   * vector vector-0.13.0.0
 -- DO NOT EDIT above, AUTOGEN versions
 License:        BSD-3-Clause
@@ -53,8 +53,8 @@ extra-source-files:
     CHANGELOG.md
     -- generated list for includes
     -- DO NOT EDIT below, AUTOGEN includes
-    include/vector.h
     include/containers.h
+    include/vector.h
     -- DO NOT EDIT above, AUTOGEN includes
 tested-with:
   GHC ==8.2.2
@@ -93,35 +93,36 @@ library
     Data.Strict.HashMap.Internal
     -- generated list for HashMap
     -- DO NOT EDIT below, AUTOGEN HashMap
-    Data.Strict.HashMap.Autogen.Strict
     Data.Strict.HashMap.Autogen.Internal
-    Data.Strict.HashMap.Autogen.Internal.Array
-    Data.Strict.HashMap.Autogen.Internal.Strict
     Data.Strict.HashMap.Autogen.Internal.List
+    Data.Strict.HashMap.Autogen.Internal.Array
+    Data.Strict.HashMap.Autogen.Internal.Debug
+    Data.Strict.HashMap.Autogen.Internal.Strict
+    Data.Strict.HashMap.Autogen.Strict
     -- DO NOT EDIT above, AUTOGEN HashMap
     Data.Strict.HashSet
     Data.Strict.IntMap
     Data.Strict.IntMap.Internal
     -- generated list for IntMap
     -- DO NOT EDIT below, AUTOGEN IntMap
-    Data.Strict.IntMap.Autogen.Strict
-    Data.Strict.IntMap.Autogen.Internal
-    Data.Strict.IntMap.Autogen.Merge.Strict
     Data.Strict.IntMap.Autogen.Strict.Internal
-    Data.Strict.IntMap.Autogen.Internal.Debug
+    Data.Strict.IntMap.Autogen.Internal
     Data.Strict.IntMap.Autogen.Internal.DeprecatedDebug
+    Data.Strict.IntMap.Autogen.Internal.Debug
+    Data.Strict.IntMap.Autogen.Strict
+    Data.Strict.IntMap.Autogen.Merge.Strict
     -- DO NOT EDIT above, AUTOGEN IntMap
     Data.Strict.IntSet
     Data.Strict.Map
     Data.Strict.Map.Internal
     -- generated list for Map
     -- DO NOT EDIT below, AUTOGEN Map
-    Data.Strict.Map.Autogen.Strict
-    Data.Strict.Map.Autogen.Internal
-    Data.Strict.Map.Autogen.Merge.Strict
     Data.Strict.Map.Autogen.Strict.Internal
+    Data.Strict.Map.Autogen.Internal
     Data.Strict.Map.Autogen.Internal.Debug
     Data.Strict.Map.Autogen.Internal.DeprecatedShowTree
+    Data.Strict.Map.Autogen.Strict
+    Data.Strict.Map.Autogen.Merge.Strict
     -- DO NOT EDIT above, AUTOGEN Map
     Data.Strict.Sequence
     Data.Strict.Sequence.Internal
@@ -134,22 +135,22 @@ library
     Data.Strict.Set
     -- generated list for ContainersUtils
     -- DO NOT EDIT below, AUTOGEN ContainersUtils
-    Data.Strict.ContainersUtils.Autogen.Coercions
-    Data.Strict.ContainersUtils.Autogen.BitUtil
-    Data.Strict.ContainersUtils.Autogen.StrictPair
-    Data.Strict.ContainersUtils.Autogen.StrictMaybe
     Data.Strict.ContainersUtils.Autogen.PtrEquality
-    Data.Strict.ContainersUtils.Autogen.State
     Data.Strict.ContainersUtils.Autogen.BitQueue
     Data.Strict.ContainersUtils.Autogen.TypeError
+    Data.Strict.ContainersUtils.Autogen.StrictMaybe
+    Data.Strict.ContainersUtils.Autogen.StrictPair
+    Data.Strict.ContainersUtils.Autogen.State
+    Data.Strict.ContainersUtils.Autogen.BitUtil
+    Data.Strict.ContainersUtils.Autogen.Coercions
     -- DO NOT EDIT above, AUTOGEN ContainersUtils
     Data.Strict.Vector
     Data.Strict.Vector.Internal
     -- generated list for Vector
     -- DO NOT EDIT below, AUTOGEN Vector
     Data.Strict.Vector.Autogen
-    Data.Strict.Vector.Autogen.Mutable
     Data.Strict.Vector.Autogen.Internal.Check
+    Data.Strict.Vector.Autogen.Mutable
     -- DO NOT EDIT above, AUTOGEN Vector
 
   include-dirs: include

--- a/strict-containers/strict-containers.cabal
+++ b/strict-containers/strict-containers.cabal
@@ -41,7 +41,7 @@ Description:
 -- DO NOT EDIT below, AUTOGEN versions
   * containers v0.6.6
   * unordered-containers v0.2.20
-  * vector vector-0.13.0.0
+  * vector vector-0.13.1.0
 -- DO NOT EDIT above, AUTOGEN versions
 License:        BSD-3-Clause
 License-File:   LICENSE

--- a/strict-containers/tests/HashMapLazy.hs
+++ b/strict-containers/tests/HashMapLazy.hs
@@ -1,9 +1,14 @@
-{-# LANGUAGE CPP                        #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-} -- because of Arbitrary (HashMap k v)
+{-# LANGUAGE CPP                       #-}
+{-# LANGUAGE NoMonomorphismRestriction #-}
+{-# LANGUAGE PatternSynonyms           #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
 
--- | Tests for the 'Data.Strict.HashMap.Autogen.Lazy' module.  We test functions by
--- comparing them to @Map@ from @containers@.
+{-# OPTIONS_GHC -fno-warn-orphans            #-} -- because of Arbitrary (HashMap k v)
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-} -- https://github.com/nick8325/quickcheck/issues/344
+
+-- | Tests for "Data.Strict.HashMap.Autogen.Lazy" and "Data.Strict.HashMap.Autogen.Strict".  We test functions by
+-- comparing them to @Map@ from @containers@. @Map@ is referred to as the /model/
+-- for 'HashMap'
 
 #if defined(STRICT)
 #define MODULE_NAME Properties.HashMapStrict
@@ -13,22 +18,23 @@
 
 module MODULE_NAME (tests) where
 
-import Control.Applicative      (Const (..))
-import Control.Monad            (guard)
+import Control.Applicative         (Const (..))
 import Data.Bifoldable
-import Data.Function            (on)
-import Data.Functor.Identity    (Identity (..))
-import Data.Hashable            (Hashable (hashWithSalt))
-import Data.Ord                 (comparing)
-import Test.QuickCheck          (Arbitrary (..), Property, elements, forAll,
-                                 (===), (==>))
-import Test.QuickCheck.Function (Fun, apply)
-import Test.QuickCheck.Poly     (A, B)
-import Test.Tasty               (TestTree, testGroup)
-import Test.Tasty.QuickCheck    (testProperty)
+import Data.Function               (on)
+import Data.Functor.Identity       (Identity (..))
+import Data.Hashable               (Hashable (hashWithSalt))
+import Data.Strict.HashMap.Autogen.Internal.Debug (Validity (..), valid)
+import Data.Ord                    (comparing)
+import Test.QuickCheck             (Arbitrary (..), Fun, Property, pattern Fn,
+                                    pattern Fn2, pattern Fn3, (===), (==>))
+import Test.QuickCheck.Poly        (A, B, C)
+import Test.Tasty                  (TestTree, testGroup)
+import Test.Tasty.QuickCheck       (testProperty)
+import Util.Key                    (Key, incKey, keyToInt)
 
-import qualified Data.Foldable as Foldable
-import qualified Data.List     as List
+import qualified Data.Foldable   as Foldable
+import qualified Data.List       as List
+import qualified Test.QuickCheck as QC
 
 #if defined(STRICT)
 import           Data.Strict.HashMap.Autogen.Strict (HashMap)
@@ -40,375 +46,24 @@ import qualified Data.Strict.HashMap.Autogen.Lazy as HM
 import qualified Data.Map.Lazy     as M
 #endif
 
--- Key type that generates more hash collisions.
-newtype Key = K { unK :: Int }
-            deriving (Arbitrary, Eq, Ord, Read, Show, Num)
-
-instance Hashable Key where
-    hashWithSalt salt k = hashWithSalt salt (unK k) `mod` 20
-
 instance (Eq k, Hashable k, Arbitrary k, Arbitrary v) => Arbitrary (HashMap k v) where
-  arbitrary = fmap (HM.fromList) arbitrary
+  arbitrary = HM.fromList <$> arbitrary
+  shrink = fmap HM.fromList . shrink . HM.toList
 
 ------------------------------------------------------------------------
--- * Properties
+-- Helpers
 
-------------------------------------------------------------------------
--- ** Instances
+type HMK  = HashMap Key
+type HMKI = HMK Int
 
-pEq :: [(Key, Int)] -> [(Key, Int)] -> Bool
-pEq xs = (M.fromList xs ==) `eq` (HM.fromList xs ==)
+sortByKey :: Ord k => [(k, v)] -> [(k, v)]
+sortByKey = List.sortBy (compare `on` fst)
 
-pNeq :: [(Key, Int)] -> [(Key, Int)] -> Bool
-pNeq xs = (M.fromList xs /=) `eq` (HM.fromList xs /=)
+toOrdMap :: Ord k => HashMap k v -> M.Map k v
+toOrdMap = M.fromList . HM.toList
 
--- We cannot compare to `Data.Map` as ordering is different.
-pOrd1 :: [(Key, Int)] -> Bool
-pOrd1 xs = compare x x == EQ
-  where
-    x = HM.fromList xs
-
-pOrd2 :: [(Key, Int)] -> [(Key, Int)] -> [(Key, Int)] -> Bool
-pOrd2 xs ys zs = case (compare x y, compare y z) of
-    (EQ, o)  -> compare x z == o
-    (o,  EQ) -> compare x z == o
-    (LT, LT) -> compare x z == LT
-    (GT, GT) -> compare x z == GT
-    (LT, GT) -> True -- ys greater than xs and zs.
-    (GT, LT) -> True
-  where
-    x = HM.fromList xs
-    y = HM.fromList ys
-    z = HM.fromList zs
-
-pOrd3 :: [(Key, Int)] -> [(Key, Int)] -> Bool
-pOrd3 xs ys = case (compare x y, compare y x) of
-    (EQ, EQ) -> True
-    (LT, GT) -> True
-    (GT, LT) -> True
-    _        -> False
-  where
-    x = HM.fromList xs
-    y = HM.fromList ys
-
-pOrdEq :: [(Key, Int)] -> [(Key, Int)] -> Bool
-pOrdEq xs ys = case (compare x y, x == y) of
-    (EQ, True)  -> True
-    (LT, False) -> True
-    (GT, False) -> True
-    _           -> False
-  where
-    x = HM.fromList xs
-    y = HM.fromList ys
-
-pReadShow :: [(Key, Int)] -> Bool
-pReadShow xs = M.fromList xs == read (show (M.fromList xs))
-
-pFunctor :: [(Key, Int)] -> Bool
-pFunctor = fmap (+ 1) `eq_` fmap (+ 1)
-
-pFoldable :: [(Int, Int)] -> Bool
-pFoldable = (List.sort . Foldable.foldr (:) []) `eq`
-            (List.sort . Foldable.foldr (:) [])
-
-pHashable :: [(Key, Int)] -> [Int] -> Int -> Property
-pHashable xs is salt =
-    x == y ==> hashWithSalt salt x === hashWithSalt salt y
-  where
-    xs' = List.nubBy (\(k,_) (k',_) -> k == k') xs
-    ys = shuffle is xs'
-    x = HM.fromList xs'
-    y = HM.fromList ys
-    -- Shuffle the list using indexes in the second
-    shuffle :: [Int] -> [a] -> [a]
-    shuffle idxs = List.map snd
-                 . List.sortBy (comparing fst)
-                 . List.zip (idxs ++ [List.maximum (0:is) + 1 ..])
-
-------------------------------------------------------------------------
--- ** Basic interface
-
-pSize :: [(Key, Int)] -> Bool
-pSize = M.size `eq` HM.size
-
-pMember :: Key -> [(Key, Int)] -> Bool
-pMember k = M.member k `eq` HM.member k
-
-pLookup :: Key -> [(Key, Int)] -> Bool
-pLookup k = M.lookup k `eq` HM.lookup k
-
-pLookupOperator :: Key -> [(Key, Int)] -> Bool
-pLookupOperator k = M.lookup k `eq` (HM.!? k)
-
-pInsert :: Key -> Int -> [(Key, Int)] -> Bool
-pInsert k v = M.insert k v `eq_` HM.insert k v
-
-pDelete :: Key -> [(Key, Int)] -> Bool
-pDelete k = M.delete k `eq_` HM.delete k
-
-newtype AlwaysCollide = AC Int
-    deriving (Arbitrary, Eq, Ord, Show)
-
-instance Hashable AlwaysCollide where
-    hashWithSalt _ _ = 1
-
--- White-box test that tests the case of deleting one of two keys from
--- a map, where the keys' hash values collide.
-pDeleteCollision :: AlwaysCollide -> AlwaysCollide -> AlwaysCollide -> Int
-                 -> Property
-pDeleteCollision k1 k2 k3 idx = (k1 /= k2) && (k2 /= k3) && (k1 /= k3) ==>
-                                HM.member toKeep $ HM.delete toDelete $
-                                HM.fromList [(k1, 1 :: Int), (k2, 2), (k3, 3)]
-  where
-    which = idx `mod` 3
-    toDelete
-        | which == 0 = k1
-        | which == 1 = k2
-        | which == 2 = k3
-        | otherwise = error "Impossible"
-    toKeep
-        | which == 0 = k2
-        | which == 1 = k3
-        | which == 2 = k1
-        | otherwise = error "Impossible"
-
-pInsertWith :: Key -> [(Key, Int)] -> Bool
-pInsertWith k = M.insertWith (+) k 1 `eq_` HM.insertWith (+) k 1
-
-pAdjust :: Key -> [(Key, Int)] -> Bool
-pAdjust k = M.adjust succ k `eq_` HM.adjust succ k
-
-pUpdateAdjust :: Key -> [(Key, Int)] -> Bool
-pUpdateAdjust k = M.update (Just . succ) k `eq_` HM.update (Just . succ) k
-
-pUpdateDelete :: Key -> [(Key, Int)] -> Bool
-pUpdateDelete k = M.update (const Nothing) k `eq_` HM.update (const Nothing) k
-
-pAlterAdjust :: Key -> [(Key, Int)] -> Bool
-pAlterAdjust k = M.alter (fmap succ) k `eq_` HM.alter (fmap succ) k
-
-pAlterInsert :: Key -> [(Key, Int)] -> Bool
-pAlterInsert k = M.alter (const $ Just 3) k `eq_` HM.alter (const $ Just 3) k
-
-pAlterDelete :: Key -> [(Key, Int)] -> Bool
-pAlterDelete k = M.alter (const Nothing) k `eq_` HM.alter (const Nothing) k
-
-
--- We choose the list functor here because we don't fuss with
--- it in alterF rules and because it has a sufficiently interesting
--- structure to have a good chance of breaking if something is wrong.
-pAlterF :: Key -> Fun (Maybe A) [Maybe A] -> [(Key, A)] -> Property
-pAlterF k f xs =
-  fmap M.toAscList (M.alterF (apply f) k (M.fromList xs))
-  ===
-  fmap toAscList (HM.alterF (apply f) k (HM.fromList xs))
-
-pAlterFAdjust :: Key -> [(Key, Int)] -> Bool
-pAlterFAdjust k =
-  runIdentity . M.alterF (Identity . fmap succ) k `eq_`
-  runIdentity . HM.alterF (Identity . fmap succ) k
-
-pAlterFInsert :: Key -> [(Key, Int)] -> Bool
-pAlterFInsert k =
-  runIdentity . M.alterF (const . Identity . Just $ 3) k `eq_`
-  runIdentity . HM.alterF (const . Identity . Just $ 3) k
-
-pAlterFInsertWith :: Key -> Fun Int Int -> [(Key, Int)] -> Bool
-pAlterFInsertWith k f =
-  runIdentity . M.alterF (Identity . Just . maybe 3 (apply f)) k `eq_`
-  runIdentity . HM.alterF (Identity . Just . maybe 3 (apply f)) k
-
-pAlterFDelete :: Key -> [(Key, Int)] -> Bool
-pAlterFDelete k =
-  runIdentity . M.alterF (const (Identity Nothing)) k `eq_`
-  runIdentity . HM.alterF (const (Identity Nothing)) k
-
-pAlterFLookup :: Key
-              -> Fun (Maybe A) B
-              -> [(Key, A)] -> Bool
-pAlterFLookup k f =
-  getConst . M.alterF (Const . apply f :: Maybe A -> Const B (Maybe A)) k
-  `eq`
-  getConst . HM.alterF (Const . apply f) k
-
-pSubmap :: [(Key, Int)] -> [(Key, Int)] -> Bool
-pSubmap xs ys = M.isSubmapOf (M.fromList xs) (M.fromList ys) ==
-                HM.isSubmapOf (HM.fromList xs) (HM.fromList ys)
-
-pSubmapReflexive :: HashMap Key Int -> Bool
-pSubmapReflexive m = HM.isSubmapOf m m
-
-pSubmapUnion :: HashMap Key Int -> HashMap Key Int -> Bool
-pSubmapUnion m1 m2 = HM.isSubmapOf m1 (HM.union m1 m2)
-
-pNotSubmapUnion :: HashMap Key Int -> HashMap Key Int -> Property
-pNotSubmapUnion m1 m2 = not (HM.isSubmapOf m1 m2) ==> HM.isSubmapOf m1 (HM.union m1 m2)
-
-pSubmapDifference :: HashMap Key Int -> HashMap Key Int -> Bool
-pSubmapDifference m1 m2 = HM.isSubmapOf (HM.difference m1 m2) m1
-
-pNotSubmapDifference :: HashMap Key Int -> HashMap Key Int -> Property
-pNotSubmapDifference m1 m2 =
-  not (HM.null (HM.intersection m1 m2)) ==>
-  not (HM.isSubmapOf m1 (HM.difference m1 m2))
-
-pSubmapDelete :: HashMap Key Int -> Property
-pSubmapDelete m = not (HM.null m) ==>
-  forAll (elements (HM.keys m)) $ \k ->
-  HM.isSubmapOf (HM.delete k m) m
-
-pNotSubmapDelete :: HashMap Key Int -> Property
-pNotSubmapDelete m =
-  not (HM.null m) ==>
-  forAll (elements (HM.keys m)) $ \k ->
-  not (HM.isSubmapOf m (HM.delete k m))
-
-pSubmapInsert :: Key -> Int -> HashMap Key Int -> Property
-pSubmapInsert k v m = not (HM.member k m) ==> HM.isSubmapOf m (HM.insert k v m)
-
-pNotSubmapInsert :: Key -> Int -> HashMap Key Int -> Property
-pNotSubmapInsert k v m = not (HM.member k m) ==> not (HM.isSubmapOf (HM.insert k v m) m)
-
-------------------------------------------------------------------------
--- ** Combine
-
-pUnion :: [(Key, Int)] -> [(Key, Int)] -> Bool
-pUnion xs ys = M.union (M.fromList xs) `eq_` HM.union (HM.fromList xs) $ ys
-
-pUnionWith :: [(Key, Int)] -> [(Key, Int)] -> Bool
-pUnionWith xs ys = M.unionWith (-) (M.fromList xs) `eq_`
-                   HM.unionWith (-) (HM.fromList xs) $ ys
-
-pUnionWithKey :: [(Key, Int)] -> [(Key, Int)] -> Bool
-pUnionWithKey xs ys = M.unionWithKey go (M.fromList xs) `eq_`
-                             HM.unionWithKey go (HM.fromList xs) $ ys
-  where
-    go :: Key -> Int -> Int -> Int
-    go (K k) i1 i2 = k - i1 + i2
-
-pUnions :: [[(Key, Int)]] -> Bool
-pUnions xss = M.toAscList (M.unions (map M.fromList xss)) ==
-              toAscList (HM.unions (map HM.fromList xss))
-
-------------------------------------------------------------------------
--- ** Transformations
-
-pMap :: [(Key, Int)] -> Bool
-pMap = M.map (+ 1) `eq_` HM.map (+ 1)
-
-pTraverse :: [(Key, Int)] -> Bool
-pTraverse xs =
-  List.sort (fmap (List.sort . M.toList) (M.traverseWithKey (\_ v -> [v + 1, v + 2]) (M.fromList (take 10 xs))))
-     == List.sort (fmap (List.sort . HM.toList) (HM.traverseWithKey (\_ v -> [v + 1, v + 2]) (HM.fromList (take 10 xs))))
-
-pMapKeys :: [(Int, Int)] -> Bool
-pMapKeys = M.mapKeys (+1) `eq_` HM.mapKeys (+1)
-
-------------------------------------------------------------------------
--- ** Difference and intersection
-
-pDifference :: [(Key, Int)] -> [(Key, Int)] -> Bool
-pDifference xs ys = M.difference (M.fromList xs) `eq_`
-                    HM.difference (HM.fromList xs) $ ys
-
-pDifferenceWith :: [(Key, Int)] -> [(Key, Int)] -> Bool
-pDifferenceWith xs ys = M.differenceWith f (M.fromList xs) `eq_`
-                        HM.differenceWith f (HM.fromList xs) $ ys
-  where
-    f x y = if x == 0 then Nothing else Just (x - y)
-
-pIntersection :: [(Key, Int)] -> [(Key, Int)] -> Bool
-pIntersection xs ys = 
-  M.intersection (M.fromList xs)
-    `eq_` HM.intersection (HM.fromList xs)
-    $ ys
-
-pIntersectionWith :: [(Key, Int)] -> [(Key, Int)] -> Bool
-pIntersectionWith xs ys = M.intersectionWith (-) (M.fromList xs) `eq_`
-                          HM.intersectionWith (-) (HM.fromList xs) $ ys
-
-pIntersectionWithKey :: [(Key, Int)] -> [(Key, Int)] -> Bool
-pIntersectionWithKey xs ys = M.intersectionWithKey go (M.fromList xs) `eq_`
-                             HM.intersectionWithKey go (HM.fromList xs) $ ys
-  where
-    go :: Key -> Int -> Int -> Int
-    go (K k) i1 i2 = k - i1 - i2
-
-------------------------------------------------------------------------
--- ** Folds
-
-pFoldr :: [(Int, Int)] -> Bool
-pFoldr = (List.sort . M.foldr (:) []) `eq` (List.sort . HM.foldr (:) [])
-
-pFoldl :: [(Int, Int)] -> Bool
-pFoldl = (List.sort . M.foldl (flip (:)) []) `eq` (List.sort . HM.foldl (flip (:)) [])
-
-pBifoldMap :: [(Int, Int)] -> Bool
-pBifoldMap xs = concatMap f (HM.toList m) == bifoldMap (:[]) (:[]) m
-  where f (k, v) = [k, v]
-        m = HM.fromList xs
-
-pBifoldr :: [(Int, Int)] -> Bool
-pBifoldr xs = concatMap f (HM.toList m) == bifoldr (:) (:) [] m
-  where f (k, v) = [k, v]
-        m = HM.fromList xs
-
-pBifoldl :: [(Int, Int)] -> Bool
-pBifoldl xs = reverse (concatMap f $ HM.toList m) == bifoldl (flip (:)) (flip (:)) [] m
-  where f (k, v) = [k, v]
-        m = HM.fromList xs
-
-pFoldrWithKey :: [(Int, Int)] -> Bool
-pFoldrWithKey = (sortByKey . M.foldrWithKey f []) `eq`
-                (sortByKey . HM.foldrWithKey f [])
-  where f k v z = (k, v) : z
-
-pFoldMapWithKey :: [(Int, Int)] -> Bool
-pFoldMapWithKey = (sortByKey . M.foldMapWithKey f) `eq`
-                  (sortByKey . HM.foldMapWithKey f)
-  where f k v = [(k, v)]
-
-pFoldrWithKey' :: [(Int, Int)] -> Bool
-pFoldrWithKey' = (sortByKey . M.foldrWithKey' f []) `eq`
-                 (sortByKey . HM.foldrWithKey' f [])
-  where f k v z = (k, v) : z
-
-pFoldlWithKey :: [(Int, Int)] -> Bool
-pFoldlWithKey = (sortByKey . M.foldlWithKey f []) `eq`
-                (sortByKey . HM.foldlWithKey f [])
-  where f z k v = (k, v) : z
-
-pFoldlWithKey' :: [(Int, Int)] -> Bool
-pFoldlWithKey' = (sortByKey . M.foldlWithKey' f []) `eq`
-                 (sortByKey . HM.foldlWithKey' f [])
-  where f z k v = (k, v) : z
-
-pFoldl' :: [(Int, Int)] -> Bool
-pFoldl' = (List.sort . M.foldl' (flip (:)) []) `eq` (List.sort . HM.foldl' (flip (:)) [])
-
-pFoldr' :: [(Int, Int)] -> Bool
-pFoldr' = (List.sort . M.foldr' (:) []) `eq` (List.sort . HM.foldr' (:) [])
-
-------------------------------------------------------------------------
--- ** Filter
-
-pMapMaybeWithKey :: [(Key, Int)] -> Bool
-pMapMaybeWithKey = M.mapMaybeWithKey f `eq_` HM.mapMaybeWithKey f
-  where f k v = guard (odd (unK k + v)) >> Just (v + 1)
-
-pMapMaybe :: [(Key, Int)] -> Bool
-pMapMaybe = M.mapMaybe f `eq_` HM.mapMaybe f
-  where f v = guard (odd v) >> Just (v + 1)
-
-pFilter :: [(Key, Int)] -> Bool
-pFilter = M.filter odd `eq_` HM.filter odd
-
-pFilterWithKey :: [(Key, Int)] -> Bool
-pFilterWithKey = M.filterWithKey p `eq_` HM.filterWithKey p
-  where p k v = odd (unK k + v)
-
-------------------------------------------------------------------------
--- ** Conversions
+isValid :: (Eq k, Hashable k, Show k) => HashMap k v -> Property
+isValid m = valid m === Valid
 
 -- The free magma is used to test that operations are applied in the
 -- same order.
@@ -421,32 +76,8 @@ instance Hashable a => Hashable (Magma a) where
   hashWithSalt s (Leaf a) = hashWithSalt s (hashWithSalt (1::Int) a)
   hashWithSalt s (Op m n) = hashWithSalt s (hashWithSalt (hashWithSalt (2::Int) m) n)
 
--- 'eq_' already calls fromList.
-pFromList :: [(Key, Int)] -> Bool
-pFromList = id `eq_` id
-
-pFromListWith :: [(Key, Int)] -> Bool
-pFromListWith kvs = (M.toAscList $ M.fromListWith Op kvsM) ==
-                    (toAscList $ HM.fromListWith Op kvsM)
-  where kvsM = fmap (fmap Leaf) kvs
-
-pFromListWithKey :: [(Key, Int)] -> Bool
-pFromListWithKey kvs = (M.toAscList $ M.fromListWithKey combine kvsM) ==
-                       (toAscList $ HM.fromListWithKey combine kvsM)
-  where kvsM = fmap (\(K k,v) -> (Leaf k, Leaf v)) kvs
-        combine k v1 v2 = Op k (Op v1 v2)
-
-pToList :: [(Key, Int)] -> Bool
-pToList = M.toAscList `eq` toAscList
-
-pElems :: [(Key, Int)] -> Bool
-pElems = (List.sort . M.elems) `eq` (List.sort . HM.elems)
-
-pKeys :: [(Key, Int)] -> Bool
-pKeys = (List.sort . M.keys) `eq` (List.sort . HM.keys)
-
 ------------------------------------------------------------------------
--- * Test list
+-- Test list
 
 tests :: TestTree
 tests =
@@ -459,135 +90,383 @@ tests =
     [
     -- Instances
       testGroup "instances"
-      [ testProperty "==" pEq
-      , testProperty "/=" pNeq
-      , testProperty "compare reflexive" pOrd1
-      , testProperty "compare transitive" pOrd2
-      , testProperty "compare antisymmetric" pOrd3
-      , testProperty "Ord => Eq" pOrdEq
-      , testProperty "Read/Show" pReadShow
-      , testProperty "Functor" pFunctor
-      , testProperty "Foldable" pFoldable
-      , testProperty "Hashable" pHashable
+      [ testGroup "Eq"
+        [ testProperty "==" $
+          \(x :: HMKI) y -> (x == y) === (toOrdMap x == toOrdMap y)
+        , testProperty "/=" $
+          \(x :: HMKI) y -> (x == y) === (toOrdMap x == toOrdMap y)
+        ]
+      , testGroup "Ord"
+        [ testProperty "compare reflexive" $
+          \(m :: HMKI) -> compare m m === EQ
+        , testProperty "compare transitive" $
+          \(x :: HMKI) y z -> case (compare x y, compare y z) of
+            (EQ, o)  -> compare x z === o
+            (o,  EQ) -> compare x z === o
+            (LT, LT) -> compare x z === LT
+            (GT, GT) -> compare x z === GT
+            (LT, GT) -> QC.property True -- ys greater than xs and zs.
+            (GT, LT) -> QC.property True
+        , testProperty "compare antisymmetric" $
+          \(x :: HMKI) y -> case (compare x y, compare y x) of
+            (EQ, EQ) -> True
+            (LT, GT) -> True
+            (GT, LT) -> True
+            _        -> False
+        , testProperty "Ord => Eq" $
+          \(x :: HMKI) y -> case (compare x y, x == y) of
+            (EQ, True)  -> True
+            (LT, False) -> True
+            (GT, False) -> True
+            _           -> False
+        ]
+      , testProperty "Read/Show" $
+        \(x :: HMKI) -> x === read (show x)
+      , testProperty "Functor" $
+        \(x :: HMKI) (Fn f :: Fun Int Int) ->
+          toOrdMap (fmap f x) === fmap f (toOrdMap x)
+      , testProperty "Foldable" $
+        \(x :: HMKI) ->
+          let f = List.sort . Foldable.foldr (:) []
+          in  f x === f (toOrdMap x)
+      , testGroup "Bifoldable"
+        [ testProperty "bifoldMap" $
+          \(m :: HMK Key) ->
+            bifoldMap (:[]) (:[]) m === concatMap (\(k, v) -> [k, v]) (HM.toList m)
+        , testProperty "bifoldr" $
+          \(m :: HMK Key) ->
+            bifoldr (:) (:) [] m === concatMap (\(k, v) -> [k, v]) (HM.toList m)
+        , testProperty "bifoldl" $
+          \(m :: HMK Key) ->
+            bifoldl (flip (:)) (flip (:)) [] m
+            ===
+            reverse (concatMap (\(k, v) -> [k, v]) (HM.toList m))
+        ]
+      , testProperty "Hashable" $
+        \(xs :: [(Key, Int)]) is salt ->
+          let xs' = List.nubBy (\(k,_) (k',_) -> k == k') xs
+              -- Shuffle the list using indexes in the second
+              shuffle :: [Int] -> [a] -> [a]
+              shuffle idxs = List.map snd
+                           . List.sortBy (comparing fst)
+                           . List.zip (idxs ++ [List.maximum (0:is) + 1 ..])
+              ys = shuffle is xs'
+              x = HM.fromList xs'
+              y = HM.fromList ys
+          in  x == y ==> hashWithSalt salt x === hashWithSalt salt y
+      ]
+    -- Construction
+    , testGroup "empty"
+      [ testProperty "valid" $ QC.once $
+        isValid (HM.empty :: HMKI)
+      ]
+    , testGroup "singleton"
+      [ testProperty "valid" $
+        \(k :: Key) (v :: A) -> isValid (HM.singleton k v)
       ]
     -- Basic interface
-    , testGroup "basic interface"
-      [ testProperty "size" pSize
-      , testProperty "member" pMember
-      , testProperty "lookup" pLookup
-      , testProperty "!?" pLookupOperator
-      , testProperty "insert" pInsert
-      , testProperty "delete" pDelete
-      , testProperty "deleteCollision" pDeleteCollision
-      , testProperty "insertWith" pInsertWith
-      , testProperty "adjust" pAdjust
-      , testProperty "updateAdjust" pUpdateAdjust
-      , testProperty "updateDelete" pUpdateDelete
-      , testProperty "alterAdjust" pAlterAdjust
-      , testProperty "alterInsert" pAlterInsert
-      , testProperty "alterDelete" pAlterDelete
-      , testProperty "alterF" pAlterF
-      , testProperty "alterFAdjust" pAlterFAdjust
-      , testProperty "alterFInsert" pAlterFInsert
-      , testProperty "alterFInsertWith" pAlterFInsertWith
-      , testProperty "alterFDelete" pAlterFDelete
-      , testProperty "alterFLookup" pAlterFLookup
-      , testGroup "isSubmapOf"
-        [ testProperty "container compatibility" pSubmap
-        , testProperty "m ⊆ m" pSubmapReflexive
-        , testProperty "m1 ⊆ m1 ∪ m2" pSubmapUnion
-        , testProperty "m1 ⊈ m2  ⇒  m1 ∪ m2 ⊈ m1" pNotSubmapUnion
-        , testProperty "m1\\m2 ⊆ m1" pSubmapDifference
-        , testProperty "m1 ∩ m2 ≠ ∅  ⇒  m1 ⊈ m1\\m2 " pNotSubmapDifference
-        , testProperty "delete k m ⊆ m" pSubmapDelete
-        , testProperty "m ⊈ delete k m " pNotSubmapDelete
-        , testProperty "k ∉ m  ⇒  m ⊆ insert k v m" pSubmapInsert
-        , testProperty "k ∉ m  ⇒  insert k v m ⊈ m" pNotSubmapInsert
+    , testProperty "size" $
+      \(x :: HMKI) -> HM.size x === M.size (toOrdMap x)
+    , testProperty "member" $
+      \(k :: Key) (m :: HMKI) -> HM.member k m === M.member k (toOrdMap m)
+    , testProperty "lookup" $
+      \(k :: Key) (m :: HMKI) -> HM.lookup k m === M.lookup k (toOrdMap m)
+    , testProperty "!?" $
+      \(k :: Key) (m :: HMKI) -> m HM.!? k === M.lookup k (toOrdMap m)
+    , testGroup "insert"
+      [ testProperty "model" $
+        \(k :: Key) (v :: Int) x ->
+          let y = HM.insert k v x
+          in  toOrdMap y === M.insert k v (toOrdMap x)
+      , testProperty "valid" $
+        \(k :: Key) (v :: Int) x -> isValid (HM.insert k v x)
+      ]
+    , testGroup "insertWith"
+      [ testProperty "insertWith" $
+        \(Fn2 f) k v (x :: HMKI) ->
+          toOrdMap (HM.insertWith f k v x) === M.insertWith f k v (toOrdMap x)
+      , testProperty "valid" $
+        \(Fn2 f) k v (x :: HMKI) -> isValid (HM.insertWith f k v x)
+      ]
+    , testGroup "delete"
+      [ testProperty "model" $
+        \(k :: Key) (x :: HMKI) ->
+          let y = HM.delete k x
+          in  toOrdMap y === M.delete k (toOrdMap x)
+      , testProperty "valid" $
+        \(k :: Key) (x :: HMKI) -> isValid (HM.delete k x)
+      ]
+    , testGroup "adjust" 
+      [ testProperty "model" $
+        \(Fn f) k (x :: HMKI) ->
+          toOrdMap (HM.adjust f k x) === M.adjust f k (toOrdMap x)
+      , testProperty "valid" $
+        \(Fn f) k (x :: HMKI) -> isValid (HM.adjust f k x)
+      ]
+    , testGroup "update" 
+      [ testProperty "model" $
+        \(Fn f) k (x :: HMKI) ->
+          toOrdMap (HM.update f k x) === M.update f k (toOrdMap x)
+      , testProperty "valid" $
+        \(Fn f) k (x :: HMKI) -> isValid (HM.update f k x)
+      ]
+    , testGroup "alter"
+      [ testProperty "model" $
+        \(Fn f) k (x :: HMKI) ->
+          toOrdMap (HM.alter f k x) === M.alter f k (toOrdMap x)
+      , testProperty "valid" $
+        \(Fn f) k (x :: HMKI) -> isValid (HM.alter f k x)
+      ]
+    , testGroup "alterF"
+      [ testGroup "model"
+        [ -- We choose the list functor here because we don't fuss with
+          -- it in alterF rules and because it has a sufficiently interesting
+          -- structure to have a good chance of breaking if something is wrong.
+          testProperty "[]" $
+          \(Fn f :: Fun (Maybe A) [Maybe A]) k (x :: HMK A) ->
+            map toOrdMap (HM.alterF f k x) === M.alterF f k (toOrdMap x)
+        , testProperty "adjust" $
+          \(Fn f) k (x :: HMKI) ->
+            let g = Identity . fmap f
+            in  fmap toOrdMap (HM.alterF g k x) === M.alterF g k (toOrdMap x)
+        , testProperty "insert" $
+          \v k (x :: HMKI) ->
+            let g = const . Identity . Just $ v
+            in  fmap toOrdMap (HM.alterF g k x) === M.alterF g k (toOrdMap x)
+        , testProperty "insertWith" $
+          \(Fn f) k v (x :: HMKI) ->
+            let g = Identity . Just . maybe v f
+            in  fmap toOrdMap (HM.alterF g k x) === M.alterF g k (toOrdMap x)
+        , testProperty "delete" $
+          \k (x :: HMKI) ->
+            let f = const (Identity Nothing)
+            in  fmap toOrdMap (HM.alterF f k x) === M.alterF f k (toOrdMap x)
+        , testProperty "lookup" $
+          \(Fn f :: Fun (Maybe A) B) k (x :: HMK A) ->
+            let g = Const . f
+            in  fmap toOrdMap (HM.alterF g k x) === M.alterF g k (toOrdMap x)
         ]
+      , testProperty "valid" $
+        \(Fn f :: Fun (Maybe A) [Maybe A]) k (x :: HMK A) ->
+          let ys = HM.alterF f k x
+          in  map valid ys === (Valid <$ ys)
+      ]
+    , testGroup "isSubmapOf"
+      [ testProperty "model" $
+        \(x :: HMKI) y -> HM.isSubmapOf x y === M.isSubmapOf (toOrdMap x) (toOrdMap y)
+      , testProperty "m ⊆ m" $
+        \(x :: HMKI) -> HM.isSubmapOf x x
+      , testProperty "m1 ⊆ m1 ∪ m2" $
+        \(x :: HMKI) y -> HM.isSubmapOf x (HM.union x y)
+      , testProperty "m1 ⊈ m2  ⇒  m1 ∪ m2 ⊈ m1" $
+        \(m1 :: HMKI) m2 -> not (HM.isSubmapOf m1 m2) ==> HM.isSubmapOf m1 (HM.union m1 m2)
+      , testProperty "m1\\m2 ⊆ m1" $
+        \(m1 :: HMKI) (m2 :: HMKI) -> HM.isSubmapOf (HM.difference m1 m2) m1
+      , testProperty "m1 ∩ m2 ≠ ∅  ⇒  m1 ⊈ m1\\m2 " $
+        \(m1 :: HMKI) (m2 :: HMKI) ->
+          not (HM.null (HM.intersection m1 m2)) ==>
+          not (HM.isSubmapOf m1 (HM.difference m1 m2))
+      , testProperty "delete k m ⊆ m" $
+        \(m :: HMKI) ->
+          not (HM.null m) ==>
+          QC.forAll (QC.elements (HM.keys m)) $ \k ->
+          HM.isSubmapOf (HM.delete k m) m
+      , testProperty "m ⊈ delete k m " $
+        \(m :: HMKI) ->
+          not (HM.null m) ==>
+          QC.forAll (QC.elements (HM.keys m)) $ \k ->
+          not (HM.isSubmapOf m (HM.delete k m))
+      , testProperty "k ∉ m  ⇒  m ⊆ insert k v m" $
+        \k v (m :: HMKI) -> not (HM.member k m) ==> HM.isSubmapOf m (HM.insert k v m)
+      , testProperty "k ∉ m  ⇒  insert k v m ⊈ m" $
+        \k v (m :: HMKI) -> not (HM.member k m) ==> not (HM.isSubmapOf (HM.insert k v m) m)
       ]
     -- Combine
-    , testProperty "union" pUnion
-    , testProperty "unionWith" pUnionWith
-    , testProperty "unionWithKey" pUnionWithKey
-    , testProperty "unions" pUnions
+    , testGroup "union"
+      [ testProperty "model" $
+        \(x :: HMKI) y ->
+          let z = HM.union x y
+          in  toOrdMap z === M.union (toOrdMap x) (toOrdMap y)
+      , testProperty "valid" $
+        \(x :: HMKI) y -> isValid (HM.union x y)
+      ]
+    , testGroup "unionWith"
+      [ testProperty "model" $
+        \(Fn2 f) (x :: HMKI) y ->
+          toOrdMap (HM.unionWith f x y) === M.unionWith f (toOrdMap x) (toOrdMap y)
+      , testProperty "valid" $
+        \(Fn2 f) (x :: HMKI) y -> isValid (HM.unionWith f x y)
+      ]
+    , testGroup "unionWithKey"
+      [ testProperty "model" $
+        \(Fn3 f) (x :: HMKI) y ->
+          toOrdMap (HM.unionWithKey f x y) === M.unionWithKey f (toOrdMap x) (toOrdMap y)
+      , testProperty "valid" $
+        \(Fn3 f) (x :: HMKI) y -> isValid (HM.unionWithKey f x y)
+      ]
+    , testGroup "unions"
+      [ testProperty "model" $
+        \(ms :: [HMKI]) -> toOrdMap (HM.unions ms) === M.unions (map toOrdMap ms)
+      , testProperty "valid" $
+        \(ms :: [HMKI]) -> isValid (HM.unions ms)
+      ]
+    , testGroup "difference"
+      [ testProperty "model" $
+        \(x :: HMKI) (y :: HMKI) ->
+          toOrdMap (HM.difference x y) === M.difference (toOrdMap x) (toOrdMap y)
+      , testProperty "valid" $
+        \(x :: HMKI) (y :: HMKI) -> isValid (HM.difference x y)
+      ]
+    , testGroup "differenceWith"
+      [ testProperty "model" $
+        \(Fn2 f) (x :: HMK A) (y :: HMK B) ->
+          toOrdMap (HM.differenceWith f x y) === M.differenceWith f (toOrdMap x) (toOrdMap y)
+      , testProperty "valid" $
+        \(Fn2 f) (x :: HMK A) (y :: HMK B) -> isValid (HM.differenceWith f x y)
+      ]
+    , testGroup "intersection"
+      [ testProperty "model" $
+        \(x :: HMKI) (y :: HMKI) ->
+          toOrdMap (HM.intersection x y) === M.intersection (toOrdMap x) (toOrdMap y)
+      , testProperty "valid" $
+        \(x :: HMKI) (y :: HMKI) ->
+          isValid (HM.intersection x y)
+      ]
+    , testGroup "intersectionWith"
+      [ testProperty "model" $
+        \(Fn2 f :: Fun (A, B) C) (x :: HMK A) (y :: HMK B) ->
+          toOrdMap (HM.intersectionWith f x y) === M.intersectionWith f (toOrdMap x) (toOrdMap y)
+      , testProperty "valid" $
+        \(Fn2 f :: Fun (A, B) C) (x :: HMK A) (y :: HMK B) ->
+          isValid (HM.intersectionWith f x y)
+      ]
+    , testGroup "intersectionWithKey"
+      [ testProperty "model" $
+        \(Fn3 f :: Fun (Key, A, B) C) (x :: HMK A) (y :: HMK B) ->
+          toOrdMap (HM.intersectionWithKey f x y)
+          ===
+          M.intersectionWithKey f (toOrdMap x) (toOrdMap y)
+      , testProperty "valid" $
+        \(Fn3 f :: Fun (Key, A, B) C) (x :: HMK A) (y :: HMK B) ->
+          isValid (HM.intersectionWithKey f x y)
+      ]
+    , testGroup "compose"
+      [ testProperty "valid" $
+        \(x :: HMK Int) (y :: HMK Key) -> isValid (HM.compose x y)
+      ]
     -- Transformations
-    , testProperty "map" pMap
-    , testProperty "traverse" pTraverse
-    , testProperty "mapKeys" pMapKeys
+    , testGroup "map"
+      [ testProperty "model" $
+        \(Fn f :: Fun A B) (m :: HMK A) -> toOrdMap (HM.map f m) === M.map f (toOrdMap m)
+      , testProperty "valid" $
+        \(Fn f :: Fun A B) (m :: HMK A) -> isValid (HM.map f m)
+      ]
+    , testGroup "traverseWithKey"
+      [ testProperty "model" $ QC.mapSize (\s -> s `div` 8) $
+        \(x :: HMKI) ->
+          let f k v = [keyToInt k + v + 1, keyToInt k + v + 2]
+              ys = HM.traverseWithKey f x
+          in  List.sort (fmap toOrdMap ys) === List.sort (M.traverseWithKey f (toOrdMap x))
+      , testProperty "valid" $ QC.mapSize (\s -> s `div` 8) $
+        \(x :: HMKI) ->
+          let f k v = [keyToInt k + v + 1, keyToInt k + v + 2]
+              ys = HM.traverseWithKey f x
+          in  fmap valid ys === (Valid <$ ys)
+      ]
+    , testGroup "mapKeys"
+      [ testProperty "model" $
+        \(m :: HMKI) -> toOrdMap (HM.mapKeys incKey m) === M.mapKeys incKey (toOrdMap m)
+      , testProperty "valid" $
+        \(Fn f :: Fun Key Key) (m :: HMKI) -> isValid (HM.mapKeys f m)
+      ]
     -- Folds
-    , testGroup "folds"
-      [ testProperty "foldr" pFoldr
-      , testProperty "foldl" pFoldl
-      , testProperty "bifoldMap" pBifoldMap
-      , testProperty "bifoldr" pBifoldr
-      , testProperty "bifoldl" pBifoldl
-      , testProperty "foldrWithKey" pFoldrWithKey
-      , testProperty "foldlWithKey" pFoldlWithKey
-      , testProperty "foldrWithKey'" pFoldrWithKey'
-      , testProperty "foldlWithKey'" pFoldlWithKey'
-      , testProperty "foldl'" pFoldl'
-      , testProperty "foldr'" pFoldr'
-      , testProperty "foldMapWithKey" pFoldMapWithKey
-      ]
-    , testGroup "difference and intersection"
-      [ testProperty "difference" pDifference
-      , testProperty "differenceWith" pDifferenceWith
-      , testProperty "intersection" pIntersection
-      , testProperty "intersectionWith" pIntersectionWith
-      , testProperty "intersectionWithKey" pIntersectionWithKey
-      ]
+    , testProperty "foldr" $
+      \(m :: HMKI) -> List.sort (HM.foldr (:) [] m) === List.sort (M.foldr (:) [] (toOrdMap m))
+    , testProperty "foldl" $
+      \(m :: HMKI) ->
+        List.sort (HM.foldl (flip (:)) [] m) === List.sort (M.foldl (flip (:)) [] (toOrdMap m))
+    , testProperty "foldrWithKey" $
+      \(m :: HMKI) ->
+        let f k v z = (k, v) : z
+        in  sortByKey (HM.foldrWithKey f [] m) === sortByKey (M.foldrWithKey f [] (toOrdMap m))
+    , testProperty "foldlWithKey" $
+      \(m :: HMKI) ->
+        let f z k v = (k, v) : z
+        in  sortByKey (HM.foldlWithKey f [] m) === sortByKey (M.foldlWithKey f [] (toOrdMap m))
+    , testProperty "foldrWithKey'" $
+      \(m :: HMKI) ->
+        let f k v z = (k, v) : z
+        in  sortByKey (HM.foldrWithKey' f [] m) === sortByKey (M.foldrWithKey' f [] (toOrdMap m))
+    , testProperty "foldlWithKey'" $
+      \(m :: HMKI) ->
+        let f z k v = (k, v) : z
+        in  sortByKey (HM.foldlWithKey' f [] m) === sortByKey (M.foldlWithKey' f [] (toOrdMap m))
+    , testProperty "foldl'" $
+      \(m :: HMKI) ->
+        List.sort (HM.foldl' (flip (:)) [] m) === List.sort (M.foldl' (flip (:)) [] (toOrdMap m))
+    , testProperty "foldr'" $
+      \(m :: HMKI) -> List.sort (HM.foldr' (:) [] m) === List.sort (M.foldr' (:) [] (toOrdMap m))
+    , testProperty "foldMapWithKey" $
+      \(m :: HMKI) ->
+        let f k v = [(k, v)]
+        in  sortByKey (HM.foldMapWithKey f m) === sortByKey (M.foldMapWithKey f (toOrdMap m))
     -- Filter
     , testGroup "filter"
-      [ testProperty "filter" pFilter
-      , testProperty "filterWithKey" pFilterWithKey
-      , testProperty "mapMaybe" pMapMaybe
-      , testProperty "mapMaybeWithKey" pMapMaybeWithKey
+      [ testProperty "model" $
+        \(Fn p) (m :: HMKI) -> toOrdMap (HM.filter p m) === M.filter p (toOrdMap m)
+      , testProperty "valid" $
+        \(Fn p) (m :: HMKI) -> isValid (HM.filter p m)
+      ]
+    , testGroup "filterWithKey"
+      [ testProperty "model" $
+        \(Fn2 p) (m :: HMKI) ->
+          toOrdMap (HM.filterWithKey p m) === M.filterWithKey p (toOrdMap m)
+      , testProperty "valid" $
+        \(Fn2 p) (m :: HMKI) -> isValid (HM.filterWithKey p m)
+      ]
+    , testGroup "mapMaybe"
+      [ testProperty "model" $
+        \(Fn f :: Fun A (Maybe B)) (m :: HMK A) ->
+          toOrdMap (HM.mapMaybe f m) === M.mapMaybe f (toOrdMap m)
+      , testProperty "valid" $
+        \(Fn f :: Fun A (Maybe B)) (m :: HMK A) -> isValid (HM.mapMaybe f m)
+      ]
+    , testGroup "mapMaybeWithKey"
+      [ testProperty "model" $
+        \(Fn2 f :: Fun (Key, A) (Maybe B)) (m :: HMK A) ->
+          toOrdMap (HM.mapMaybeWithKey f m) === M.mapMaybeWithKey f (toOrdMap m)
+      , testProperty "valid" $
+        \(Fn2 f :: Fun (Key, A) (Maybe B)) (m :: HMK A) ->
+          isValid (HM.mapMaybeWithKey f m)
       ]
     -- Conversions
-    , testGroup "conversions"
-      [ testProperty "elems" pElems
-      , testProperty "keys" pKeys
-      , testProperty "fromList" pFromList
-      , testProperty "fromListWith" pFromListWith
-      , testProperty "fromListWithKey" pFromListWithKey
-      , testProperty "toList" pToList
+    , testProperty "elems" $
+      \(m :: HMKI) -> List.sort (HM.elems m) === List.sort (M.elems (toOrdMap m))
+    , testProperty "keys" $
+      \(m :: HMKI) -> List.sort (HM.keys m) === List.sort (M.keys (toOrdMap m))
+    , testGroup "fromList"
+      [ testProperty "model" $
+        \(kvs :: [(Key, Int)]) -> toOrdMap (HM.fromList kvs) === M.fromList kvs
+      , testProperty "valid" $
+        \(kvs :: [(Key, Int)]) -> isValid (HM.fromList kvs)
       ]
+    , testGroup "fromListWith"
+      [ testProperty "model" $
+        \(kvs :: [(Key, Int)]) ->
+          let kvsM = map (fmap Leaf) kvs
+          in  toOrdMap (HM.fromListWith Op kvsM) === M.fromListWith Op kvsM
+      , testProperty "valid" $
+        \(Fn2 f) (kvs :: [(Key, A)]) -> isValid (HM.fromListWith f kvs)
+      ]
+    , testGroup "fromListWithKey"
+      [ testProperty "model" $
+        \(kvs :: [(Key, Int)]) ->
+          let kvsM = fmap (\(k,v) -> (Leaf (keyToInt k), Leaf v)) kvs
+              combine k v1 v2 = Op k (Op v1 v2)
+          in  toOrdMap (HM.fromListWithKey combine kvsM) === M.fromListWithKey combine kvsM
+      , testProperty "valid" $
+        \(Fn3 f) (kvs :: [(Key, A)]) -> isValid (HM.fromListWithKey f kvs)
+      ]
+    , testProperty "toList" $
+      \(m :: HMKI) -> List.sort (HM.toList m) === List.sort (M.toList (toOrdMap m))
     ]
-
-------------------------------------------------------------------------
--- * Model
-
-type Model k v = M.Map k v
-
--- | Check that a function operating on a 'HashMap' is equivalent to
--- one operating on a 'Model'.
-eq :: (Eq a, Eq k, Hashable k, Ord k)
-   => (Model k v -> a)       -- ^ Function that modifies a 'Model'
-   -> (HM.HashMap k v -> a)  -- ^ Function that modified a 'HashMap' in the same
-                             -- way
-   -> [(k, v)]               -- ^ Initial content of the 'HashMap' and 'Model'
-   -> Bool                   -- ^ True if the functions are equivalent
-eq f g xs = g (HM.fromList xs) == f (M.fromList xs)
-
-infix 4 `eq`
-
-eq_ :: (Eq k, Eq v, Hashable k, Ord k)
-    => (Model k v -> Model k v)            -- ^ Function that modifies a 'Model'
-    -> (HM.HashMap k v -> HM.HashMap k v)  -- ^ Function that modified a
-                                           -- 'HashMap' in the same way
-    -> [(k, v)]                            -- ^ Initial content of the 'HashMap'
-                                           -- and 'Model'
-    -> Bool                                -- ^ True if the functions are
-                                           -- equivalent
-eq_ f g = (M.toAscList . f) `eq` (toAscList . g)
-
-infix 4 `eq_`
-
-------------------------------------------------------------------------
--- * Helpers
-
-sortByKey :: Ord k => [(k, v)] -> [(k, v)]
-sortByKey = List.sortBy (compare `on` fst)
-
-toAscList :: Ord k => HM.HashMap k v -> [(k, v)]
-toAscList = List.sortBy (compare `on` fst) . HM.toList

--- a/strict-containers/tests/Tests/Bundle.hs
+++ b/strict-containers/tests/Tests/Bundle.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE TypeOperators #-}
 module Tests.Bundle ( tests ) where
 
 import Boilerplater

--- a/strict-containers/tests/Tests/Vector/Property.hs
+++ b/strict-containers/tests/Tests/Vector/Property.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE TypeOperators #-}
 module Tests.Vector.Property
   ( CommonContext
   , VanillaContext
@@ -31,6 +32,7 @@ import Control.Monad
 import Control.Monad.ST
 import qualified Data.Traversable as T (Traversable(..))
 import Data.Orphans ()
+import Data.Maybe
 import Data.Foldable (foldrM)
 import qualified Data.Vector.Generic as V
 import qualified Data.Vector.Generic.Mutable as MV

--- a/strict-containers/tests/Utilities.hs
+++ b/strict-containers/tests/Utilities.hs
@@ -1,10 +1,13 @@
+{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeOperators #-}
 module Utilities where
 
 import Test.QuickCheck
 
 import Data.Foldable
+import Data.Bifunctor
 import qualified Data.Strict.Vector as DV
 import qualified Data.Vector.Generic as DVG
 import qualified Data.Vector.Primitive as DVP
@@ -14,7 +17,6 @@ import qualified Data.Vector.Fusion.Bundle as S
 
 import Control.Monad (foldM, foldM_, zipWithM, zipWithM_)
 import Control.Monad.Trans.Writer
-import Data.Function (on)
 import Data.Functor.Identity
 import Data.List ( sortBy )
 import Data.Maybe (catMaybes)
@@ -67,67 +69,61 @@ class (Testable (EqTest a), Conclusion (EqTest a)) => TestData a where
   unmodel :: Model a -> a
 
   type EqTest a
+  type instance EqTest a = Property
   equal :: a -> a -> EqTest a
+  default equal :: (Eq a, EqTest a ~ Property) => a -> a -> EqTest a
+  equal x y = property (x == y)
+
 
 instance (Eq a, TestData a) => TestData (S.Bundle v a) where
   type Model (S.Bundle v a) = [Model a]
   model   = map model  . S.toList
   unmodel = S.fromList . map unmodel
 
-  type EqTest (S.Bundle v a) = Property
-  equal x y = property (x == y)
-
 instance (Eq a, TestData a) => TestData (DV.Vector a) where
   type Model (DV.Vector a) = [Model a]
   model   = map model    . DV.toList
   unmodel = DV.fromList . map unmodel
-
-  type EqTest (DV.Vector a) = Property
-  equal x y = property (x == y)
 
 instance (Eq a, DVP.Prim a, TestData a) => TestData (DVP.Vector a) where
   type Model (DVP.Vector a) = [Model a]
   model   = map model    . DVP.toList
   unmodel = DVP.fromList . map unmodel
 
-  type EqTest (DVP.Vector a) = Property
-  equal x y = property (x == y)
-
 instance (Eq a, DVS.Storable a, TestData a) => TestData (DVS.Vector a) where
   type Model (DVS.Vector a) = [Model a]
   model   = map model    . DVS.toList
   unmodel = DVS.fromList . map unmodel
-
-  type EqTest (DVS.Vector a) = Property
-  equal x y = property (x == y)
 
 instance (Eq a, DVU.Unbox a, TestData a) => TestData (DVU.Vector a) where
   type Model (DVU.Vector a) = [Model a]
   model   = map model    . DVU.toList
   unmodel = DVU.fromList . map unmodel
 
-  type EqTest (DVU.Vector a) = Property
-  equal x y = property (x == y)
-
 #define id_TestData(ty) \
 instance TestData ty where { \
   type Model ty = ty;        \
   model = id;                \
-  unmodel = id;              \
-                             \
-  type EqTest ty = Property; \
-  equal x y = property (x == y) }
+  unmodel = id }             \
 
 id_TestData(())
 id_TestData(Bool)
 id_TestData(Int)
-id_TestData(Float)
-id_TestData(Double)
 id_TestData(Ordering)
 
-bimapEither :: (a -> b) -> (c -> d) -> Either a c -> Either b d
-bimapEither f _ (Left a) = Left (f a)
-bimapEither _ g (Right c) = Right (g c)
+instance TestData Float where
+  type Model Float = Float
+  model = id
+  unmodel = id
+
+  equal x y = property (x == y || (isNaN x && isNaN y))
+
+instance TestData Double where
+  type Model Double = Double
+  model = id
+  unmodel = id
+
+  equal x y = property (x == y || (isNaN x && isNaN y))
 
 -- Functorish models
 -- All of these need UndecidableInstances although they are actually well founded. Oh well.
@@ -136,56 +132,35 @@ instance (Eq a, TestData a) => TestData (Maybe a) where
   model = fmap model
   unmodel = fmap unmodel
 
-  type EqTest (Maybe a) = Property
-  equal x y = property (x == y)
-
 instance (Eq a, TestData a, Eq b, TestData b) => TestData (Either a b) where
   type Model (Either a b) = Either (Model a) (Model b)
-  model = bimapEither model model
-  unmodel = bimapEither unmodel unmodel
-
-  type EqTest (Either a b) = Property
-  equal x y = property (x == y)
+  model = bimap model model
+  unmodel = bimap unmodel unmodel
 
 instance (Eq a, TestData a) => TestData [a] where
   type Model [a] = [Model a]
   model = fmap model
   unmodel = fmap unmodel
 
-  type EqTest [a] = Property
-  equal x y = property (x == y)
-
 instance (Eq a, TestData a) => TestData (Identity a) where
   type Model (Identity a) = Identity (Model a)
   model = fmap model
   unmodel = fmap unmodel
-
-  type EqTest (Identity a) = Property
-  equal = (property .) . on (==) runIdentity
 
 instance (Eq a, TestData a, Eq b, TestData b, Monoid a) => TestData (Writer a b) where
   type Model (Writer a b) = Writer (Model a) (Model b)
   model = mapWriter model
   unmodel = mapWriter unmodel
 
-  type EqTest (Writer a b) = Property
-  equal = (property .) . on (==) runWriter
-
 instance (Eq a, Eq b, TestData a, TestData b) => TestData (a,b) where
   type Model (a,b) = (Model a, Model b)
   model (a,b) = (model a, model b)
   unmodel (a,b) = (unmodel a, unmodel b)
 
-  type EqTest (a,b) = Property
-  equal x y = property (x == y)
-
 instance (Eq a, Eq b, Eq c, TestData a, TestData b, TestData c) => TestData (a,b,c) where
   type Model (a,b,c) = (Model a, Model b, Model c)
   model (a,b,c) = (model a, model b, model c)
   unmodel (a,b,c) = (unmodel a, unmodel b, unmodel c)
-
-  type EqTest (a,b,c) = Property
-  equal x y = property (x == y)
 
 instance (Arbitrary a, Show a, TestData a, TestData b) => TestData (a -> b) where
   type Model (a -> b) = Model a -> Model b
@@ -311,9 +286,6 @@ izipWith3 = withIndexFirst zipWith3
 
 ifilter :: (Int -> a -> Bool) -> [a] -> [a]
 ifilter f = map snd . withIndexFirst filter f
-
-mapMaybe :: (a -> Maybe b) -> [a] -> [b]
-mapMaybe f = catMaybes . map f
 
 imapMaybe :: (Int -> a -> Maybe b) -> [a] -> [b]
 imapMaybe f = catMaybes . withIndexFirst map f

--- a/strict-containers/tests/Utilities.hs
+++ b/strict-containers/tests/Utilities.hs
@@ -8,7 +8,8 @@ import Test.QuickCheck
 
 import Data.Foldable
 import Data.Bifunctor
-import qualified Data.Strict.Vector as DV
+import qualified Data.Strict.Vector as DSV
+import qualified Data.Vector as DV
 import qualified Data.Vector.Generic as DVG
 import qualified Data.Vector.Primitive as DVP
 import qualified Data.Vector.Storable as DVS
@@ -99,6 +100,11 @@ instance (Eq a, DVU.Unbox a, TestData a) => TestData (DVU.Vector a) where
   type Model (DVU.Vector a) = [Model a]
   model   = map model    . DVU.toList
   unmodel = DVU.fromList . map unmodel
+
+instance (Eq a, TestData a) => TestData (DSV.Vector a) where
+  type Model (DSV.Vector a) = [Model a]
+  model   = map model    . DSV.toList
+  unmodel = DSV.fromList . map unmodel
 
 #define id_TestData(ty) \
 instance TestData ty where { \
@@ -346,3 +352,9 @@ limitUnfolds f (theirs, ours)
     | ours >= 0
     , Just (out, theirs') <- f theirs = Just (out, (theirs', ours - 1))
     | otherwise                       = Nothing
+
+instance Arbitrary a => Arbitrary (DSV.Vector a) where
+  arbitrary = fmap DSV.fromList arbitrary
+
+instance CoArbitrary a => CoArbitrary (DSV.Vector a) where
+    coarbitrary = coarbitrary . DSV.toList

--- a/strict-containers/tests/seq-properties.hs
+++ b/strict-containers/tests/seq-properties.hs
@@ -30,7 +30,7 @@ import Data.Semigroup (stimes, stimesMonoid)
 import Data.Traversable (Traversable(traverse), sequenceA)
 import Prelude hiding (
   lookup, null, length, take, drop, splitAt,
-  foldl, foldl1, foldr, foldr1, scanl, scanl1, scanr, scanr1,
+  foldl, foldl', foldl1, foldr, foldr1, scanl, scanl1, scanr, scanr1,
   filter, reverse, replicate, zip, zipWith, zip3, zipWith3,
   all, sum)
 import qualified Prelude


### PR DESCRIPTION
The `unordered-containers` and `vector` packages have been updated. Still waiting for containers (see https://github.com/haskell/containers/issues/1012 ).

When `containers` is added, still need to add `ghc-9.10` to the CI build matrix.